### PR TITLE
Fix avoiding UObjects' dangling pointer.

### DIFF
--- a/Plugins/RealtimeDelay/Source/RealtimeDelay/Public/RealtimeDelayAction.h
+++ b/Plugins/RealtimeDelay/Source/RealtimeDelay/Public/RealtimeDelayAction.h
@@ -20,7 +20,7 @@ public:
 
 	FRealtimeDelayAction(float Duration, const FLatentActionInfo& LatentActionInfo);
 	virtual ~FRealtimeDelayAction() {}
-	void UpdateOperation(float ElapsedTime);
+	void UpdateOperation(float ElapsedTime, UObject* InObject);
 };
 
 /**
@@ -34,6 +34,9 @@ class URealtimeDelayActionManager : public UGameInstanceSubsystem, public FTicka
 protected:
 	TArray<FRealtimeDelayAction*> Actions;
 	static URealtimeDelayActionManager* _Instance;
+
+	UPROPERTY()
+	TMap<int32, UObject*> CallbackObjects;
 
 public:
 	virtual void Initialize(FSubsystemCollectionBase& Collection)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ English Document: [README_en.md](README_en.md)
 
 * UE4.26 - UE4.27
 * UE5.0 - UE5.4
+
 基本的な機能しか使っていないので、大体のUE4/5のバージョンで動くと思います。稼働報告をくれると嬉しいです。
 
 ## 使い方

--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ English Document: [README_en.md](README_en.md)
 
 ## 動作環境
 
-* UE4.26.x
-* UE5.2.x
-
+* UE4.26 - UE4.27
+* UE5.0 - UE5.4
 基本的な機能しか使っていないので、大体のUE4/5のバージョンで動くと思います。稼働報告をくれると嬉しいです。
 
 ## 使い方
@@ -27,5 +26,7 @@ English Document: [README_en.md](README_en.md)
 MIT
 
 ## 更新履歴
+* 2024/07/11 v0.1.1 不具合修正
+  * Realtime Delay実行中にオブジェクトが破棄された場合にメモリアクセス違反になる可能性があるバグを修正
 * 2023/08/19 v0.1.0公開
 

--- a/README_en.md
+++ b/README_en.md
@@ -10,8 +10,8 @@
 
 ## Supported Environment
 
-* UE4.26.x
-* UE5.2.x
+* UE4.26 - UE4.27
+* UE5.0 - UE5.4
 
 I believe it will work with most UE4 and UE5 versions as only basic functionality is used. It would be great if you could give me a running report.
 
@@ -25,4 +25,6 @@ I believe it will work with most UE4 and UE5 versions as only basic functionalit
 MIT
 
 ## Update History
+* 2024/07/11 v0.1.1 Fixes bugs
+  * Fixed a bug that could cause a memory access violation if an object was destroyed during Realtime Delay execution
 * 2023/08/19 v0.1.0 released


### PR DESCRIPTION
# Fixes
* Fixed a possible memory access violation if the callback object had already been destroyed.
